### PR TITLE
Return log messages in case you don't want stdout

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = function(category, level, template) {
                 .replace(/\${ ?timestamp ?}/g, new Date().toUTCString())
                 .replace(/\${ ?level ?}/g, l)
                 .replace(/\${ ?category ?}/g, category);
+            var msg;
             if (arguments[0] instanceof Error) {
                 var err = arguments[0];
                 // Error objects passed directly.
@@ -24,12 +25,14 @@ module.exports = function(category, level, template) {
                     if (_(val).isString() || _(val).isNumber()) lines.push('    ' + key + ': ' + val);
                 });
 
-                console.log('%s %s', prefix, lines.join('\n'));
+                msg = lines.join('\n');
             } else {
                 // Normal string messages.
-                var message = util.format.apply(this, arguments);
-                console.log('%s %s', prefix, message);
+                msg = util.format.apply(this, arguments);
             }
+
+            console.log('%s %s', prefix, msg);
+            return util.format('%s %s', prefix, msg);
         };
         return logger;
     }, {});

--- a/test/fastlog.test.js
+++ b/test/fastlog.test.js
@@ -14,6 +14,16 @@ describe('string logging', function() {
         assert.equal(spy.callCount, 1);
     });
 
+    it('should return messages', function() {
+        var log = fastlog();
+
+        assert.ok(/\[.+\] \[debug\] \[default\] foo/.test(log.debug('foo')));
+        assert.ok(/\[.+\] \[info\] \[default\] foo/.test(log.info('foo')));
+        assert.ok(/\[.+\] \[warn\] \[default\] foo/.test(log.warn('foo')));
+        assert.ok(/\[.+\] \[error\] \[default\] foo/.test(log.error('foo')));
+        assert.ok(/\[.+\] \[fatal\] \[default\] foo/.test(log.fatal('foo')));
+    });
+
     it('should use different log levels', function() {
         var log = fastlog();
 


### PR DESCRIPTION
Makes the fastlog functions return the message as well as send it to stdout. Useful if maybe you want to capture the logs and send them to a file or something.

cc @willwhite 