### PR TITLE
Allow setting category per env var

### DIFF
--- a/bin/fastlog.js
+++ b/bin/fastlog.js
@@ -4,7 +4,7 @@ var split = require('split');
 var args = require('minimist')(process.argv.slice(2));
 
 var fastlog = require('..')(
-  args.category || 'default',
+  args.category || process.env.FASTLOG_CATEGORY || 'default',
   process.env.FASTLOG_LEVEL,
   process.env.FASTLOG_PREFIX
 );


### PR DESCRIPTION
Would allow me to set the `FASTLOG_CATEGORY` once per script, that calls other scripts using fastlog without aliasing it.

For Docker containers that allows to differentiate between different containers in the logs.