### PR TITLE
added support for global prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ logger.error('This town ain\'t big enough for the two of us!');
 // error [configured] <Fri, 05 Dec 2014 02:10:48 GMT> This town ain't big enough for the two of us!
 ```
 
+It's also possible to set a global prefix:
+- Configure global prefix by specifying a `FASTLOG_GLOBAL_PREFIX` environment variable.
+```javascript
+process.env.FASTLOG_GLOBAL_PREFIX = '[ipAddress]';
+```
+
+```javascript
+var logger = require('fastlog')('configured', 'error', '${level} [${ category }] <${timestamp}>');
+logger.error('You\'ve got a friend in me.');
+// [ipAddress] error [configured] <Fri, 05 Dec 2014 02:10:48 GMT> You've got a friend in me.
+```
+
 ## Usage via shell scripts
 
 You may also use fastlog in shell scripts. First, make sure fastlog is installed globally

--- a/index.js
+++ b/index.js
@@ -4,6 +4,10 @@ var util = require('util');
 module.exports = function(category, level, template) {
     category = category || 'default';
     template = template || '[${timestamp}] [${level}] [${category}]';
+    if (process.env.FASTLOG_GLOBAL_PREFIX) {
+        template = process.env.FASTLOG_GLOBAL_PREFIX + ' ' + template;
+    }
+
     var levels = ['debug', 'info', 'warn', 'error', 'fatal'];
     return _(levels).reduce(function(logger, l) {
         logger[l] = function() {

--- a/test/fastlog.test.js
+++ b/test/fastlog.test.js
@@ -2,7 +2,6 @@ var assert = require('assert');
 var sinon = require('sinon');
 var fastlog = require('../index.js');
 
-var util = require('util');
 var spy = sinon.spy(console, 'log');
 
 describe('string logging', function() {
@@ -86,5 +85,15 @@ describe('string logging', function() {
         log.error('to infinity and beyond!');
         assert.ok(spy.calledWith('%s %s', sinon.match(/\[error\] \{configured\} -- .+?:/), 'to infinity and beyond!'));
         assert.equal(spy.callCount, 1);
+    });
+
+    it('should include FASTLOG_GLOBAL_PREFIX in prefix', function() {
+        process.env.FASTLOG_GLOBAL_PREFIX = '[global prefix]';
+        var log = fastlog();
+        log.error('reach for the sky!');
+        assert.ok(
+            spy.calledWith('%s %s', sinon.match(/\[global prefix\] \[.+\] \[error\] \[default\]/), 'reach for the sky!')
+        );
+        delete process.env.FASTLOG_GLOBAL_PREFIX;
     });
 });


### PR DESCRIPTION
Adds support for FASTLOG_GLOBAL_PREFIX environment variable

e.g.
```javascript
process.env.FASTLOG_GLOBAL_PREFIX = '[ipAddress]';
var logger = require('fastlog')('configured', 'error', '${level} [${ category }] <${timestamp}>');
logger.error('You\'ve got a friend in me.');
// [ipAddress] error [configured] <Fri, 05 Dec 2014 02:10:48 GMT> You've got a friend in me.
```

## why this might be useful:
Currently there's no way to ensure that all the logs in your application are using the same prefix.
For instance when you're including a dependency that's logging warnings (assuming that it's using fastlog for that). With the use of FASTLOG_GLOBAL_PREFIX it's easy.

For my use case, I'd like to include the EC2 ip address and be able to query logs for different instances later on.


